### PR TITLE
remove dtype attribute from FloatTensor

### DIFF
--- a/example/mnist/main.go
+++ b/example/mnist/main.go
@@ -111,7 +111,6 @@ func runTest(runner *menoh.Runner, inputPath, outputPath string) error {
 	// classify input array
 	dims := input.GetDims()
 	inputTensor := &menoh.FloatTensor{
-		Dtype: menoh.TypeFloat,
 		Dims:  []int32{int32(dims[0]), int32(dims[1]), int32(dims[2]), int32(dims[3])},
 		Array: convertToFloat32Array(input.GetRawData()),
 	}

--- a/example/vgg16/README.md
+++ b/example/vgg16/README.md
@@ -136,7 +136,6 @@ resizedImg := cropAndResize(img, width, height)
 oneHotFloats := toOneHotFloats(resizedImg, channel)
 // make Tensor to input the runner
 resizedImgTensor := &menoh.FloatTensor{
-	Dtype: menoh.TypeFloat,
 	Dims:  []int32{1, 3, 224, 224},
 	Array: oneHotFloats,
 }

--- a/example/vgg16/main.go
+++ b/example/vgg16/main.go
@@ -44,7 +44,6 @@ func main() {
 	}
 	resizedImg := cropAndResize(img, width, height)
 	resizedImgTensor := &menoh.FloatTensor{
-		Dtype: menoh.TypeFloat,
 		Dims:  []int32{batch, channel, height, width},
 		Array: toOneHotFloats(resizedImg, channel),
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -189,7 +189,6 @@ func TestGetInput(t *testing.T) {
 			t.Fatalf("input variable should be get, %v", err)
 		}
 		expected := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{1, 3},
 			Array: []float32{0., 0., 0.},
 		}
@@ -219,7 +218,6 @@ func TestRunWithTensorAndGetOutput(t *testing.T) {
 
 	t.Run("run with intput variable", func(t *testing.T) {
 		input := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{1, 3},
 			Array: []float32{0., 1., 2.},
 		}
@@ -233,7 +231,6 @@ func TestRunWithTensorAndGetOutput(t *testing.T) {
 				t.Fatalf("the runner should return the output, %v", err)
 			}
 			expected := &FloatTensor{
-				Dtype: TypeFloat,
 				Dims:  []int32{1, 5},
 				Array: []float32{0., 0., 15., 96., 177},
 			}
@@ -245,7 +242,6 @@ func TestRunWithTensorAndGetOutput(t *testing.T) {
 
 			t.Run("run next input", func(t *testing.T) {
 				input2 := &FloatTensor{
-					Dtype: TypeFloat,
 					Dims:  []int32{1, 3},
 					Array: []float32{0., 0.5, 1.},
 				}
@@ -259,7 +255,6 @@ func TestRunWithTensorAndGetOutput(t *testing.T) {
 						t.Fatalf("the runner should return the output, %v", err)
 					}
 					expected := &FloatTensor{
-						Dtype: TypeFloat,
 						Dims:  []int32{1, 5},
 						Array: []float32{0., 0., 8., 51., 94},
 					}
@@ -294,7 +289,6 @@ func TestRunAndOutputs(t *testing.T) {
 	t.Run("run with map input", func(t *testing.T) {
 		inputs := map[string]Tensor{
 			"input": &FloatTensor{
-				Dtype: TypeFloat,
 				Dims:  []int32{1, 3},
 				Array: []float32{0., 1., 2.},
 			},
@@ -310,7 +304,6 @@ func TestRunAndOutputs(t *testing.T) {
 				t.Fatal("the runner should return the output")
 			}
 			expected := &FloatTensor{
-				Dtype: TypeFloat,
 				Dims:  []int32{1, 5},
 				Array: []float32{0., 0., 15., 96., 177},
 			}
@@ -338,7 +331,6 @@ func TestRunAndOutputs(t *testing.T) {
 						t.Fatal("the runner should return the output")
 					}
 					expected := &FloatTensor{
-						Dtype: TypeFloat,
 						Dims:  []int32{1, 5},
 						Array: []float32{0., 0., 8., 51., 94},
 					}

--- a/tensor.go
+++ b/tensor.go
@@ -34,7 +34,6 @@ func newTensorHandle(dtype TypeDtype, dims ...int32) Tensor {
 		len *= int(d)
 	}
 	return &FloatTensor{
-		Dtype: dtype,
 		Dims:  dims,
 		Array: make([]float32, len),
 	}
@@ -47,7 +46,6 @@ func newTensorHandleByPtr(dtype TypeDtype, ptr unsafe.Pointer, dims ...int32) Te
 		len *= int(d)
 	}
 	return &FloatTensor{
-		Dtype: dtype,
 		Dims:  dims,
 		Array: (*[1 << 31]float32)(ptr)[:len],
 	}
@@ -75,7 +73,6 @@ func updateArray(src, dst Tensor) error {
 
 // FloatTensor represents float32 Tessor.
 type FloatTensor struct {
-	Dtype TypeDtype
 	Dims  []int32
 	Array []float32
 }
@@ -85,7 +82,7 @@ func (t *FloatTensor) ptr() unsafe.Pointer {
 }
 
 func (t *FloatTensor) dtype() TypeDtype {
-	return t.Dtype
+	return TypeFloat
 }
 
 // Size returns array size.

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -7,12 +7,10 @@ import (
 func TestUpdateArray(t *testing.T) {
 	t.Run("update array", func(t *testing.T) {
 		src := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{5},
 			Array: []float32{1., 2., 3., 4., 5.},
 		}
 		dst := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{5},
 			Array: []float32{0., 0., 0., 0., 0.},
 		}
@@ -27,12 +25,10 @@ func TestUpdateArray(t *testing.T) {
 	})
 	t.Run("update not same size", func(t *testing.T) {
 		src := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{5},
 			Array: make([]float32, 5),
 		}
 		dst := &FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{4},
 			Array: make([]float32, 4),
 		}
@@ -45,7 +41,6 @@ func TestUpdateArray(t *testing.T) {
 func TestFloatTensorWriteFloat(t *testing.T) {
 	t.Run("write a value", func(t *testing.T) {
 		tensor := FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{5},
 			Array: []float32{0., 0., 0., 0., 0.},
 		}
@@ -61,7 +56,6 @@ func TestFloatTensorWriteFloat(t *testing.T) {
 	})
 	t.Run("write to out of range", func(t *testing.T) {
 		tensor := FloatTensor{
-			Dtype: TypeFloat,
 			Dims:  []int32{5},
 			Array: []float32{0., 0., 0., 0., 0.},
 		}


### PR DESCRIPTION
`FloatTensor` has only float32 array, and does not have to set dtype on making. **This fix breaks backward compatibility.**